### PR TITLE
Version handling for Java and Google App Engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Wahlzeit: Open Source Software for Photo Rating Sites
 
 
-
 ## PART I: INTRODUCTION
 
 Wahlzeit is an open source web application that lets users upload photos and rate photos of other users on a 1..10 scale. Users get to present their best photos and learn what other users thought of theirs. 
@@ -15,46 +14,52 @@ Starting Wahlzeit 2.0, Wahlzeit is a Google App Engine app. It can be run on you
 For more information, please see http://github.com/dirkriehle/wahlzeit and http://osr.cs.fau.de.
 
 
-
 ## PART II: WAHLZEIT SETUP
 
 ### Set-up development for Wahlzeit
 
-  1. Create your own repository by forking Wahlzeit from dirkriehle to *yourname*
-  2. Install **Java JDK**, set **JAVA_HOME**, and install **git**
-  3. On the command line, create or choose a project directory and go there 
-  4. Run ```git clone https://github.com/yourname/wahlzeit.git```
+  1. Install **Java JDK**¹
+  2. Set ``JAVA_HOME``
+  2. Install ``git``
+  3. If you don't have one yet, create a Github account (required)
+  4. Create your own repository by forking Wahlzeit from **dirkriehle** to **&lt;yourname&gt;**
+  5. On the command line, create or choose a project directory and go there 
+  6. Run ```git clone https://github.com/<yourname>/wahlzeit.git```
 
 
 ### Run Wahlzeit on your local machine
   1. On the command line, ```cd wahlzeit```
   2. Run ```./gradlew appengineRun```
-  3. Wait until all gradle and project dependencies have been downloaded and the local instance has been started
-  4. Open [http://localhost:8080](http://localhost:8080) to try out Wahlzeit on your machine
+  3. Wait until all gradle and project dependencies have been downloaded and the local instance has been started, which could take some minutes
+  4. Open [``http://localhost:8080``](http://localhost:8080) to try out Wahlzeit on your machine
 
 
 ### Debug Wahlzeit on your local machine
   1. Run Wahlzeit on your local machine (see above)
-  2. Create a remote java debug configuration in your IDE with host **localhost** and port **8000** (not 8080)
+  2. Create a remote java debug configuration in your IDE with host ``localhost`` and port ``8000`` (not ``8080``)
 
 
 ### Deploy Wahlzeit to Google App Engine
 
 **Create a Google App Engine instance:**
   1. If you don't have one yet, create a Google account (required)
-  2. Go to https://console.developers.google.com and login with your Google account
-  3. In the developers console, select ```create a project```
-    1. Choose a project name, called below *yourproj*
+  2. Go to [https://console.developers.google.com](https://console.developers.google.com) and login with your Google account
+  3. In the developers console, select **create a project**
+    1. Choose a project name, called below ``<yourproj>``
     2. Accept the terms of service, for better or worse
 
 **Configure your repository and deploy Wahlzeit**
   1. Configure your project:
-    1. Open the file [/src/main/webapp/WEB-INF/appengine-web.xml](/src/main/webapp/WEB-INF/appengine-web.xml)
-    2. Replace the project name with *yourproj*: \<application\>yourproj\</application\>
-    3. Save and close the appengine-web.xml
+    1. Open the file [``/src/main/webapp/WEB-INF/appengine-web.xml``](/src/main/webapp/WEB-INF/appengine-web.xml)
+    2. Replace ``<application>dirkriehle-wahlzeit</application>`` with `\<application\><yourproj>\</application\>` where `<yourproj>` is your previously choosen project name
+    3. Save and close the `appengine-web.xml`
   2. Run ```./gradlew appengineUpdate```
   3. If a browser window pops up and asks for permission, accept it
-  4. Copy the code from the browser window to your gradle console
-  5. If everything works out, you will find your project at https://yourproj.appspot.com
+  4. Copy the code from the browser window to your gradle console and hit enter
+  5. If everything works out, you will find your project at [``https://<yourproj>.appspot.com``](https://<yourproj>.appspot.com)
 
 Done!
+
+--
+
+¹ Gradle compiles automatically to JDK 1.7, because later versions are not yet supported by Google App Engine Standard Environment

--- a/build.gradle
+++ b/build.gradle
@@ -2,9 +2,13 @@ apply plugin: 'java'
 apply plugin: 'war'
 apply plugin: 'appengine'
 
+// Google App Engine Standard Environment supports Java 7 only (as from August 2016, https://cloud.google.com/appengine/docs)
+sourceCompatibility = 1.7 // Java version compatibility to use when compiling Java source.
+targetCompatibility = 1.7 // Java version to generate classes for.
+
 buildscript {
     ext {
-        gaeVersion = '1.9.26'
+        gaeVersion = '1.9.42'
     }
     repositories {
         mavenCentral()


### PR DESCRIPTION
* Java runtime environment version limited to 1.7 (Java 7), because Java 8 is not supported in Google App Engine (Standard Environment)
* Google App Engine version updated from 1.9.26 to 1.9.42 (current)