### PR TITLE
java 8 migration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,3 @@
-
 buildscript {
     repositories {
         mavenCentral()
@@ -18,17 +17,18 @@ repositories {
 
 apply plugin: 'java'
 apply plugin: 'war'
+/* if there is a warning regarding deprecated behaviour caused by 'DefaultSourceSetOutput.getClassesDir'
+ * see https://github.com/GoogleCloudPlatform/gradle-appengine-plugin/issues/290 */
 apply plugin: 'appengine'
 
 // check if JAVA_HOME is set, otherwise build tasks will fail
 gradle.taskGraph.whenReady {
     graph ->
-    if (System.env.'JAVA_HOME' == null) {
-        throw new GradleException("JAVA_HOME not set. Please set it, otherwise this task can not be executed.")
-    }
-    else {
-        println "JAVA_HOME = " + System.env.'JAVA_HOME'
-    }
+        if (System.env.'JAVA_HOME' == null) {
+            throw new GradleException("JAVA_HOME not set. Please set it, otherwise this task can not be executed.")
+        } else {
+            println "JAVA_HOME = " + System.env.'JAVA_HOME'
+        }
 }
 
 repositories {
@@ -38,7 +38,7 @@ repositories {
 dependencies {
     // https://cloud.google.com/appengine/docs/standard/java/release-notes
 
-    providedCompile group: 'javax.servlet', name: 'servlet-api', version:'2.5'
+    providedCompile group: 'javax.servlet', name: 'servlet-api', version: '2.5'
     compile 'com.google.appengine:appengine:+'
 
     appengineSdk 'com.google.appengine:appengine-java-sdk:+'
@@ -75,6 +75,5 @@ appengine {
     }
 }
 
-// Google App Engine Standard Environment supports Java 7 only (as from August 2016, https://cloud.google.com/appengine/docs)
-sourceCompatibility = 1.7 // Java version compatibility to use when compiling Java source.
-targetCompatibility = 1.7 // Java version to generate classes for.
+sourceCompatibility = 1.8 // Java version compatibility to use when compiling Java source.
+targetCompatibility = 1.8 // Java version to generate classes for.

--- a/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/src/main/webapp/WEB-INF/appengine-web.xml
@@ -3,7 +3,8 @@
 
     <application>dirkriehle-wahlzeit</application>
     <version>1</version>
-
+    <!-- see https://cloud.google.com/appengine/docs/standard/java/migrating-to-java8-->
+    <runtime>java8</runtime>
     <threadsafe>true</threadsafe>
     <sessions-enabled>true</sessions-enabled>
     <runtime>java8</runtime>


### PR DESCRIPTION
I migrated my fork to java 1.8 and I figured it would be also valuebale for future projects. 

Actually, I intended to get rid of all warnings from graddle and google appengine when building the project. But the appengine plugin for gradle is still working on an issue ( See [link  ](https://github.com/GoogleCloudPlatform/gradle-appengine-plugin/issues/290))
Besides, according to [google cloud plattform ](https://cloud.google.com/appengine/docs/standard/java/migrating-to-java8)  it now supports Java 8. 

