### PR TITLE
Add script to run/build/test the project inside a Docker container

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ For more information, please see http://github.com/dirkriehle/wahlzeit and http:
   2. Create a remote java debug configuration in your IDE with host ``localhost`` and port ``8000`` (not ``8080``)
 
 
+### Run Wahlzeit inside a Docker container
+  1. Run ```docker/runInDocker.sh appengineRun```
+  2. Or with another Gradle task as argument, e.g. ```docker/runInDocker.sh test```   
+  3. Open [``http://localhost:8080``](http://localhost:8080) to try out Wahlzeit inside a Docker container
+  
+  
 ### Deploy Wahlzeit to Google App Engine
 
 **Create a Google App Engine instance:**

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ For more information, please see http://github.com/dirkriehle/wahlzeit and http:
 
 
 ### Run Wahlzeit inside a Docker container
-  1. Run ```docker/runInDocker.sh appengineRun```
-  2. Or with another Gradle task as argument, e.g. ```docker/runInDocker.sh test```   
+  1. Run ```./runInDocker.sh appengineRun```
+  2. Or with another Gradle task as argument, e.g. ```./runInDocker.sh test```   
   3. Open [``http://localhost:8080``](http://localhost:8080) to try out Wahlzeit inside a Docker container
   
   

--- a/docker/runInDocker.sh
+++ b/docker/runInDocker.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+TASK="appengineRun"
+
+if [ ! -z "$1" ]; then
+    TASK="$1"
+fi
+
+CURRENT_DIR=${PWD##*/}
+if [ "$CURRENT_DIR" = "docker" ]; then
+    cd ..
+fi
+
+docker run -it --rm --name wahlzeitJDK08 \
+-v "$(pwd)":/usr/src/wahlzeit \
+-w /usr/src/wahlzeit \
+--network=host \
+-p 8080:8080 \
+gradle:4.10-jdk10-slim \
+gradle "$TASK"

--- a/runInDocker.sh
+++ b/runInDocker.sh
@@ -6,11 +6,6 @@ if [ ! -z "$1" ]; then
     TASK="$1"
 fi
 
-CURRENT_DIR=${PWD##*/}
-if [ "$CURRENT_DIR" = "docker" ]; then
-    cd ..
-fi
-
 docker run -it --rm --name wahlzeitJDK08 \
 -v "$(pwd)":/usr/src/wahlzeit \
 -w /usr/src/wahlzeit \


### PR DESCRIPTION
The runInDocker.sh script allows to run/build/test the Wahlzeit project inside a Docker container.
This way it's easy to test the project without an installed Java JDK, or test it with a new version of the Java JDK.