### PR TITLE
Fix build error with JUnit 4.13-beta

### DIFF
--- a/src/test/java/org/wahlzeit/testEnvironmentProvider/UserServiceProvider.java
+++ b/src/test/java/org/wahlzeit/testEnvironmentProvider/UserServiceProvider.java
@@ -20,7 +20,7 @@ public class UserServiceProvider extends ExternalResource {
 	}
 
 	@Override
-	protected void after() {
+	protected void after() throws Throwable {
 		super.after();
 	}
 }


### PR DESCRIPTION
Otherwise the test fails with the following error:

```
> Task :compileTestJava FAILED
/home/chris/Dev/wahlzeit/src/test/java/org/wahlzeit/testEnvironmentProvider/UserServiceProvider.java:24: error: unreported exception Throwable; must be caught or declared to be thrown
                super.after();
                           ^
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
1 error

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':compileTestJava'.
> Compilation failed; see the compiler error output for details.
```

see also https://fsi.cs.fau.de/forum/thread/16767-Da-ist-eventuell-was-kaputt-aber-nicht-bei-mir

As this is caused by a JUnit-update, I would recommend to pin all dependency versions to prevent this in the future.

@andreas-bauer 