### PR TITLE
Set appengine to fix version 1.9.76

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,12 +39,13 @@ dependencies {
     // https://cloud.google.com/appengine/docs/standard/java/release-notes
 
     providedCompile group: 'javax.servlet', name: 'servlet-api', version:'2.5'
-    compile 'com.google.appengine:appengine:+'
-
-    appengineSdk 'com.google.appengine:appengine-java-sdk:+'
-
-    compile 'com.google.appengine:appengine-api-1.0-sdk:+'
-    compile 'com.google.appengine.tools:appengine-gcs-client:+'
+    
+    def appengineVersion = '1.9.76'
+    compile "com.google.appengine:appengine:${appengineVersion}"
+    appengineSdk "com.google.appengine:appengine-java-sdk:${appengineVersion}"
+    compile "com.google.appengine:appengine-api-1.0-sdk:${appengineVersion}"
+    compile "com.google.appengine.tools:appengine-gcs-client:+"
+    
     compile 'com.googlecode.objectify:objectify:5.1.21'
     //compile 'javax.servlet:servlet-api:2.5' // GAE works with only with 2.5
     compile 'commons-fileupload:commons-fileupload:1.3.3'


### PR DESCRIPTION
Every time a new AppEngine version is released adjustments in the Dockerfile are required. Without adjustments, the Docker image build fails. 

A fix AppEngine version avoids this unpredictable problem.