### PR TITLE
Remove JAVA_HOME env check because it is not necessary

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ For more information, please see http://github.com/dirkriehle/wahlzeit and http:
 - Install **Java JDK** 8 or higher. We recommended you to use Java JDK 11.
 - An easy way to manage Java JDKs and JREs is by using [SDKMAN](https://sdkman.io/). With SDKMAN you can install the Java SDK with the following command:
  `sdk install java 11.0.8.j9-adpt`
-- Ensure `JAVA_HOME` environment variable is set.
+- Ensure `java -version` can be executed from the command line.
 - [optional] Install [Docker](https://docs.docker.com/get-docker/) and [Docker Compose](https://docs.docker.com/compose/install/) to use the container deployment option.
 - Create your own repository by forking Wahlzeit from **dirkriehle** to your GitHub-account.
  

--- a/build.gradle
+++ b/build.gradle
@@ -30,17 +30,6 @@ dependencies {
     testImplementation 'junit:junit:4.12'
 }
 
-gradle.taskGraph.whenReady {
-    // check if JAVA_HOME is set, otherwise build tasks will fail
-    graph ->
-    if (System.env.'JAVA_HOME' == null) {
-        throw new GradleException("JAVA_HOME not set!")
-    }
-    else {
-        println "JAVA_HOME = " + System.env.'JAVA_HOME'
-    }
-}
-
 test {
     filter {
         includeTestsMatching "org.wahlzeit.*"


### PR DESCRIPTION
The `JAVA_HOME` env is not required to run the application.
Therefore, the extra step of setting and ensure the `JAVA_HOME` env should be removed.

In the past Tomcat needed this env. 