### PR TITLE
ErrorDto with ExceptionMapper, MIME-Types and Response in Resource

### DIFF
--- a/src/main/java/org/wahlzeit_revisited/dto/ErrorDto.java
+++ b/src/main/java/org/wahlzeit_revisited/dto/ErrorDto.java
@@ -1,0 +1,14 @@
+package org.wahlzeit_revisited.dto;
+
+public class ErrorDto {
+
+    private String msg;
+
+    public ErrorDto(String msg) {
+        this.msg = msg;
+    }
+
+    public String getMsg() {
+        return msg;
+    }
+}

--- a/src/main/java/org/wahlzeit_revisited/dto/UserCreationDto.java
+++ b/src/main/java/org/wahlzeit_revisited/dto/UserCreationDto.java
@@ -6,7 +6,7 @@ public class UserCreationDto {
      * members
      */
 
-    String username;
+    String name;
     String email;
     String password;
 
@@ -22,12 +22,12 @@ public class UserCreationDto {
      * getter/setter
      */
 
-    public String getUsername() {
-        return username;
+    public String getName() {
+        return name;
     }
 
-    public void setUsername(String username) {
-        this.username = username;
+    public void setName(String name) {
+        this.name = name;
     }
 
     public String getEmail() {

--- a/src/main/java/org/wahlzeit_revisited/dto/UserDto.java
+++ b/src/main/java/org/wahlzeit_revisited/dto/UserDto.java
@@ -9,17 +9,15 @@ public class UserDto {
     private Long id;
     private String name;
     private String email;
-    private String password;
 
     /*
      * constructor
      */
 
-    public UserDto(Long id, String name, String email, String password) {
+    public UserDto(Long id, String name, String email) {
         this.id = id;
         this.name = name;
         this.email = email;
-        this.password = password;
     }
 
     /*
@@ -50,11 +48,4 @@ public class UserDto {
         this.email = email;
     }
 
-    public String getPassword() {
-        return password;
-    }
-
-    public void setPassword(String password) {
-        this.password = password;
-    }
 }

--- a/src/main/java/org/wahlzeit_revisited/resource/ExceptionToResponseMapper.java
+++ b/src/main/java/org/wahlzeit_revisited/resource/ExceptionToResponseMapper.java
@@ -1,0 +1,31 @@
+package org.wahlzeit_revisited.resource;
+
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
+import org.wahlzeit_revisited.dto.ErrorDto;
+import org.wahlzeit_revisited.utils.SysLog;
+
+@Provider
+public class ExceptionToResponseMapper implements ExceptionMapper<Throwable> {
+
+    @Override
+    public Response toResponse(Throwable exception) {
+        int statusCode = Response.Status.INTERNAL_SERVER_ERROR.getStatusCode();
+        ErrorDto errorDto;
+
+        if (exception instanceof WebApplicationException) {
+            // WebApplicationExceptions are thrown intentionally, just wrap them up in a dto
+            WebApplicationException thrownException = (WebApplicationException) exception;
+            statusCode = thrownException.getResponse().getStatus();
+            errorDto = new ErrorDto(thrownException.getMessage());
+        } else {
+            // All others exceptions are not intended, log then and wrap them up.
+            SysLog.logThrowable(exception);
+            errorDto = new ErrorDto("Unknown error - one may look at the server logs");
+        }
+
+        return Response.status(statusCode).entity(errorDto).build();
+    }
+}

--- a/src/main/java/org/wahlzeit_revisited/resource/PhotoResource.java
+++ b/src/main/java/org/wahlzeit_revisited/resource/PhotoResource.java
@@ -7,67 +7,58 @@ import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import org.wahlzeit_revisited.auth.AccessRights;
+import org.wahlzeit_revisited.dto.PhotoDto;
 import org.wahlzeit_revisited.model.User;
 import org.wahlzeit_revisited.service.PhotoService;
-import org.wahlzeit_revisited.utils.SysLog;
+
+import java.sql.SQLException;
+import java.util.List;
 
 
 @Path("api/photo")
-@Consumes(MediaType.APPLICATION_JSON)
-@Produces(MediaType.APPLICATION_JSON)
 public class PhotoResource extends AbstractResource {
 
     @Inject
     public PhotoService service;
 
     @GET
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
     @RolesAllowed(AccessRights.ADMINISTRATOR_ROLE)
-    public Response getPhotos() {
-        try {
-            return service.getPhotos();
-        } catch (Exception e) {
-            SysLog.logThrowable(e);
-            return buildServerError();
-        }
+    public Response getPhotos() throws SQLException {
+        List<PhotoDto> responseDto = service.getPhotos();
+        return Response.ok(responseDto).build();
     }
 
     @POST
+    @Consumes(MediaType.MEDIA_TYPE_WILDCARD)
+    @Produces(MediaType.APPLICATION_JSON)
     @RolesAllowed(AccessRights.USER_ROLE)
-    public Response addPhoto(byte[] photoBlob) {
+    public Response addPhoto(byte[] photoBlob) throws SQLException {
         User user = getAuthorizedUser();
-
-        try {
-            return service.addPhoto(user, photoBlob);
-        } catch (Exception e) {
-            SysLog.logThrowable(e);
-            return buildServerError();
-        }
+        PhotoDto responseDto = service.addPhoto(user, photoBlob);
+        return Response.ok(responseDto).build();
     }
 
     @GET
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
     @Path("/{id}")
     @PermitAll
-    public Response getPhoto(@PathParam("id") Long photoId) {
-        try {
-            return service.getPhoto(photoId);
-        } catch (Exception e) {
-            SysLog.logThrowable(e);
-            return buildServerError();
-        }
+    public Response getPhoto(@PathParam("id") Long photoId) throws SQLException {
+        PhotoDto responseDto = service.getPhoto(photoId);
+        return Response.ok(responseDto).build();
     }
 
     @DELETE
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
     @Path("/{id}")
     @RolesAllowed(AccessRights.USER_ROLE)
-    public Response removePhoto(@PathParam("id") Long photoId) {
+    public Response removePhoto(@PathParam("id") Long photoId) throws SQLException {
         User user = getAuthorizedUser();
-
-        try {
-            return service.removePhoto(user, photoId);
-        } catch (Exception e) {
-            SysLog.logThrowable(e);
-            return buildServerError();
-        }
+        PhotoDto photoDto = service.removePhoto(user, photoId);
+        return Response.ok(photoDto).build();
     }
 
 }

--- a/src/main/java/org/wahlzeit_revisited/resource/UserResource.java
+++ b/src/main/java/org/wahlzeit_revisited/resource/UserResource.java
@@ -11,8 +11,12 @@ import org.wahlzeit.services.SysLog;
 import org.wahlzeit_revisited.auth.AccessRights;
 import org.wahlzeit_revisited.dto.LoginRequestDto;
 import org.wahlzeit_revisited.dto.UserCreationDto;
+import org.wahlzeit_revisited.dto.UserDto;
 import org.wahlzeit_revisited.model.User;
 import org.wahlzeit_revisited.service.UserService;
+
+import java.sql.SQLException;
+import java.util.List;
 
 @Path("api/user")
 @Consumes(MediaType.APPLICATION_JSON)
@@ -24,57 +28,41 @@ public class UserResource extends AbstractResource {
 
     @GET
     @RolesAllowed(AccessRights.ADMINISTRATOR_ROLE)
-    public Response getUsers() {
-        try {
-            return service.getUsers();
-        } catch (Exception e) {
-            SysLog.logThrowable(e);
-            return buildServerError();
-        }
+    public Response getUsers() throws SQLException {
+        List<UserDto> responseDto = service.getUsers();
+        return Response.ok(responseDto).build();
     }
 
     @POST
     @PermitAll
-    public Response createUser(UserCreationDto creationDto) {
-        if (creationDto.getUsername() == null || creationDto.getEmail() == null || creationDto.getPassword() == null) {
+    public Response createUser(UserCreationDto creationDto) throws SQLException {
+        if (creationDto.getName() == null || creationDto.getEmail() == null || creationDto.getPassword() == null) {
             return buildBadRequest();
         }
 
-        try {
-            return service.createUser(creationDto.getUsername(), creationDto.getEmail(), creationDto.getPassword());
-        } catch (Exception e) {
-            SysLog.logThrowable(e);
-            return buildServerError();
-        }
+        UserDto responseDto = service.createUser(creationDto.getName(), creationDto.getEmail(), creationDto.getPassword());
+        return Response.ok(responseDto).build();
     }
 
     @Path("/login")
     @POST
     @PermitAll
-    public Response login(LoginRequestDto creationDto) {
+    public Response login(LoginRequestDto creationDto) throws SQLException {
         if (creationDto.getEmail() == null || creationDto.getPassword() == null) {
             return buildBadRequest();
         }
 
-        try {
-            return service.login(creationDto.getEmail(), creationDto.getPassword());
-        } catch (Exception e) {
-            SysLog.logThrowable(e);
-            return buildServerError();
-        }
+        UserDto responseDto = service.login(creationDto.getEmail(), creationDto.getPassword());
+        return Response.ok(responseDto).build();
+
     }
 
     @DELETE
     @RolesAllowed(AccessRights.USER_ROLE)
-    public Response deleteUser() {
+    public Response deleteUser() throws SQLException {
         User user = getAuthorizedUser();
-
-        try {
-            return service.deleteUser(user);
-        } catch (Exception e) {
-            SysLog.logThrowable(e);
-            return buildServerError();
-        }
+        UserDto responseDto = service.deleteUser(user);
+        return Response.ok(responseDto).build();
     }
 
 }

--- a/src/main/java/org/wahlzeit_revisited/service/Transformer.java
+++ b/src/main/java/org/wahlzeit_revisited/service/Transformer.java
@@ -18,7 +18,7 @@ public class Transformer {
 
     public UserDto transform(User user) {
         assertIsNotNull(user);
-        return new UserDto(user.getId(), user.getName(), user.getEmail(), user.getPassword());
+        return new UserDto(user.getId(), user.getName(), user.getEmail());
     }
 
     public PhotoDto transform(Photo photo) {

--- a/src/test/java/org/wahlzeit_revisited/repository/UserRepositoryIT.java
+++ b/src/test/java/org/wahlzeit_revisited/repository/UserRepositoryIT.java
@@ -109,7 +109,7 @@ public class UserRepositoryIT extends BaseModelTest {
     @Test
     public void test_getUserForAuth() throws SQLException {
         // arrange
-        String expectedEmail = buildUniqueEmail("loginTest@fau.de");
+        String expectedEmail = buildUniqueEmail("loginTest");
         String expectedPassword = "StrongPassword123";
         User expectedUser = factory.createUser(NAME, expectedEmail, expectedPassword, AccessRights.USER);
         expectedUser = repository.insert(expectedUser);

--- a/src/test/java/org/wahlzeit_revisited/service/PhotoServiceIT.java
+++ b/src/test/java/org/wahlzeit_revisited/service/PhotoServiceIT.java
@@ -1,6 +1,6 @@
 package org.wahlzeit_revisited.service;
 
-import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.NotFoundException;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -39,10 +39,9 @@ public class PhotoServiceIT extends BaseModelTest {
     @Test
     public void test_getPhotos() throws SQLException {
         // act
-        Response response = service.getPhotos();
+        List<PhotoDto> photoDtos = service.getPhotos();
 
         // assert
-        List<PhotoDto> photoDtos = assertSuccessfulResponse(response);
         Assert.assertNotNull(photoDtos);
     }
 
@@ -53,10 +52,9 @@ public class PhotoServiceIT extends BaseModelTest {
         user = userRepository.insert(user);
 
         // act
-        Response response = service.addPhoto(user, new byte[]{});
+        PhotoDto responseDto = service.addPhoto(user, new byte[]{});
 
         // assert
-        PhotoDto responseDto = assertSuccessfulResponse(response);
         Assert.assertNotNull(responseDto);
     }
 
@@ -65,13 +63,12 @@ public class PhotoServiceIT extends BaseModelTest {
         // arrange
         User user = userFactory.createUser();
         user = userRepository.insert(user);
-        PhotoDto expectedDto = assertSuccessfulResponse(service.addPhoto(user, new byte[]{}));
+        PhotoDto expectedDto = service.addPhoto(user, new byte[]{});
 
         // act
-        Response response = service.getPhoto(expectedDto.getId());
+        PhotoDto actualDto = service.getPhoto(expectedDto.getId());
 
         // assert
-        PhotoDto actualDto = assertSuccessfulResponse(response);
         Assert.assertEquals(expectedDto.getId(), actualDto.getId());
         Assert.assertEquals(expectedDto.getPath(), actualDto.getPath());
         Assert.assertEquals(expectedDto.getWidth(), actualDto.getWidth());
@@ -83,13 +80,12 @@ public class PhotoServiceIT extends BaseModelTest {
         // arrange
         User user = userFactory.createUser();
         user = userRepository.insert(user);
-        PhotoDto expectedDto = assertSuccessfulResponse(service.addPhoto(user, new byte[]{}));
+        PhotoDto expectedDto = service.addPhoto(user, new byte[]{});
 
         // act
-        Response response = service.getUserPhotos(user.getId());
+        List<PhotoDto> responseDto = service.getUserPhotos(user.getId());
 
         // assert
-        List<PhotoDto> responseDto = assertSuccessfulResponse(response);
         Assert.assertEquals(1, responseDto.size());
         Assert.assertEquals(expectedDto.getId(), responseDto.get(0).getId());
         Assert.assertEquals(expectedDto.getPath(), responseDto.get(0).getPath());
@@ -97,34 +93,22 @@ public class PhotoServiceIT extends BaseModelTest {
         Assert.assertEquals(expectedDto.getHeight(), responseDto.get(0).getHeight());
     }
 
-    @Test
+    @Test(expected = NotFoundException.class)
     public void test_removePhoto() throws SQLException {
         // arrange
         User user = userFactory.createUser();
         user = userRepository.insert(user);
-        PhotoDto expectedDto = assertSuccessfulResponse(service.addPhoto(user, new byte[]{}));
+        PhotoDto expectedDto = service.addPhoto(user, new byte[]{});
 
         // act
-        Response response = service.removePhoto(user, expectedDto.getId());
+        PhotoDto responseDto = service.removePhoto(user, expectedDto.getId());
 
         // assert
-        PhotoDto responseDto = assertSuccessfulResponse(response);
-        Assert.assertNotEquals(Response.Status.OK.getStatusCode(), service.getPhoto(expectedDto.getId()).getStatus());
+        service.getPhoto(expectedDto.getId());
         Assert.assertEquals(expectedDto.getId(), responseDto.getId());
         Assert.assertEquals(expectedDto.getPath(), responseDto.getPath());
         Assert.assertEquals(expectedDto.getWidth(), responseDto.getWidth());
         Assert.assertEquals(expectedDto.getHeight(), responseDto.getHeight());
     }
 
-    /*
-     * helpers
-     */
-
-    @SuppressWarnings("unchecked")
-    protected <T> T assertSuccessfulResponse(Response response) {
-        if (response.getStatus() < 200 || response.getStatus() > 299) {
-            Assert.fail("Invalid Statuscode: " + response.getStatus());
-        }
-        return (T) response.getEntity();
-    }
 }

--- a/src/test/java/org/wahlzeit_revisited/service/UserServiceIT.java
+++ b/src/test/java/org/wahlzeit_revisited/service/UserServiceIT.java
@@ -1,5 +1,6 @@
 package org.wahlzeit_revisited.service;
 
+import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.core.Response;
 import org.junit.Assert;
 import org.junit.Before;
@@ -35,10 +36,9 @@ public class UserServiceIT extends BaseModelTest {
     @Test
     public void test_getUsers() throws SQLException {
         // act
-        Response response = service.getUsers();
+        List<UserDto> userDtos = service.getUsers();
 
         // assert
-        List<UserDto> userDtos = assertSuccessfulResponse(response);
         Assert.assertNotNull(userDtos);
     }
 
@@ -50,32 +50,28 @@ public class UserServiceIT extends BaseModelTest {
         String expectedPassword = "TestPassword123";
 
         // act
-        Response response = service.createUser(expectedUsername, expectedEmail, expectedPassword);
+        UserDto actualUserDto = service.createUser(expectedUsername, expectedEmail, expectedPassword);
 
         // assert
-        UserDto actualUserDto = assertSuccessfulResponse(response);
         Assert.assertEquals(expectedEmail, actualUserDto.getEmail());
         Assert.assertEquals(expectedUsername, actualUserDto.getName());
-        Assert.assertEquals(expectedPassword, actualUserDto.getPassword());
     }
 
-    @Test
+    @Test(expected = NotFoundException.class)
     public void test_deleteUser() throws SQLException {
         // arrange
         User deleteUser = new UserFactory().createUser();
         deleteUser = userRepository.insert(deleteUser);
 
         // act
-        Response response = service.deleteUser(deleteUser);
+        UserDto actualUserDto = service.deleteUser(deleteUser);
 
         // assert
-        UserDto actualUserDto = assertSuccessfulResponse(response);
-        Response loginResponse = service.login(deleteUser.getEmail(), deleteUser.getPassword());
-        Assert.assertNotEquals(Response.Status.OK.getStatusCode(), loginResponse.getStatus());
+        service.login(deleteUser.getEmail(), deleteUser.getPassword());
+
         Assert.assertEquals(deleteUser.getId(), actualUserDto.getId());
         Assert.assertEquals(deleteUser.getName(), actualUserDto.getName());
         Assert.assertEquals(deleteUser.getEmail(), actualUserDto.getEmail());
-        Assert.assertEquals(deleteUser.getPassword(), actualUserDto.getPassword());
     }
 
     @Test
@@ -85,14 +81,12 @@ public class UserServiceIT extends BaseModelTest {
         expectedUser = userRepository.insert(expectedUser);
 
         // act
-        Response response = service.login(expectedUser.getEmail(), expectedUser.getPassword());
+        UserDto actualUserDto = service.login(expectedUser.getEmail(), expectedUser.getPassword());
 
         // assert
-        UserDto actualUserDto = assertSuccessfulResponse(response);
         Assert.assertEquals(expectedUser.getId(), actualUserDto.getId());
         Assert.assertEquals(expectedUser.getName(), actualUserDto.getName());
         Assert.assertEquals(expectedUser.getEmail(), actualUserDto.getEmail());
-        Assert.assertEquals(expectedUser.getPassword(), actualUserDto.getPassword());
     }
 
     /*


### PR DESCRIPTION
@georg-schwarz 

- Added an ErrorDto
- Fixed MimeTypes in `AuthFilter` by returning the `ErrorDto`
- Fixed MimeTypes in `PhotoService` by adjusting the annotations
- Added class `ExceptionToResponseMapper` to always return a ErrorDto

- Removed `password` field from UserDto
- Embeddded userId in PhotoDto
- UserDto getById(userId) endpoint
- Login with username and password
