### PR TITLE
Improve Dockerfile Cacheing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,12 +8,15 @@ WORKDIR /builder
 # Copy Gradle file
 COPY *.gradle /builder/
 
-# Copy sources
-COPY src /builder/src
-
 # Copy Gradle resources
 COPY gradle /builder/gradle
 COPY gradlew /builder/gradlew
+
+# Since this is the first execution of gradlew, it will download the gradle binary.
+RUN ./gradlew -v
+
+# Copy sources
+COPY src /builder/src
 
 # Test project
 RUN ./gradlew test

--- a/Dockerfile.simple
+++ b/Dockerfile.simple
@@ -3,12 +3,15 @@ FROM adoptopenjdk/openjdk11-openj9:alpine-slim
 # Copy Gradle file
 COPY *.gradle /app/
 
-# Copy sources
-COPY src /app/src
-
 # Copy Gradle resources
 COPY gradle /app/gradle
 COPY gradlew /app/gradlew
+
+# Since this is the first execution of gradlew, it will download the gradle binary.
+RUN ./gradlew -v
+
+# Copy sources
+COPY src /app/src
 
 WORKDIR /app
 


### PR DESCRIPTION
Upon the first execution of gradlew, the gradle binary specified in gradle/wrapper/gradle-wrapper.properties will be downloaded. This means that everytime ./gradlew test was executed during image building, the binary was downloaded.

I added an additional step, that will initiliaze gradlew, to improve the usage of image cacheing.